### PR TITLE
Put limits on what makes synopsebot interested

### DIFF
--- a/synopsebot.pl
+++ b/synopsebot.pl
@@ -9,10 +9,14 @@ package Synopsebot {
         if ($args->{body} eq 'synopsebot: botsnack!') {
             return "om nom nom"
         }
-        if ($args->{body} =~ /S(\d+)\:(\d+)/) {
+        if ($args->{body} =~ /S(\d\d)\:(\d+)/) {
+            return
+                unless $2 <= 9999;
             return "Link: http://perlcabal.org/syn/S$1.html#line_$2"
         }
-        if ($args->{body} =~ /#(\d{4,})/) {
+        if ($args->{body} =~ /#(\d{5,})/) {
+            return
+                unless 18400 <= $1 && $1 < 200000;
             return "Link: https://rt.perl.org/rt3//Public/Bug/Display.html?id=$1"
         }
     }


### PR DESCRIPTION
Rationale for the numbers:
- All synopses are numbered with two digits, and there's no reason to suspect that'll change
- Biggest line number (5394) is from S03-operators.pod, and so 9999 is a comfortable maximum
- The first perl6 RT ticket had number #18400
- We're currently at RT ticket number #122716, and a quick estimate shows that the max is growing
  at around 5_000 a year; thus it'll take us ~15.5 years to reach 200_000
